### PR TITLE
fix: audit vulnerabilities + USB mount refresh (0.0.45)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.42] - 2026-05-09
+
+### Security
+- Updated `pnpm.overrides` to force `flatted` ≥ 3.4.2 (fixes prototype pollution, GHSA-rf6f-7fwh-wjgh) and `picomatch` ≥ 4.0.4 (fixes ReDoS and glob-matching injection, GHSA-c2c7-rcm5-vvqj / GHSA-3v7f-55p6-f55p).
+
 ## [0.0.41] - 2026-04-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.45] - 2026-05-09
+
+### Fixed
+- Read subprocess environment from `/proc/self/environ` instead of `os.environ` so that `DBUS_SESSION_BUS_ADDRESS` and `XDG_RUNTIME_DIR` (cleared by PyInstaller at startup) are present when invoking `systemd-run --user`.
+
+## [0.0.44] - 2026-05-09
+
+### Fixed
+- Strip `LD_LIBRARY_PATH` from the `systemd-run` subprocess environment so it uses system libs rather than the PyInstaller bundle's `libcrypto`, which lacks the `OPENSSL_3.4.0` symbol required by `libsystemd`.
+
+## [0.0.43] - 2026-05-09
+
+### Fixed
+- USB mount refresh now works without any sudoers entries. Replaced `sudo -n mount/mkdir` with `systemd-run --user udisksctl mount`, which runs inside the deck user's systemd session where the polkit agent can authorise the mount without a password prompt.
+
 ## [0.0.42] - 2026-05-09
 
 ### Security

--- a/main.py
+++ b/main.py
@@ -160,30 +160,21 @@ def _discover_usb_partitions() -> List[UsbPartition]:
 
 
 def _mount_usb_devices() -> List[str]:
-    """Mount any unmounted USB partitions via sudo mount.
+    """Mount any unmounted USB partitions via udisksctl in the user session.
 
-    Scans /dev/sd* for partition block devices (e.g. /dev/sda1) that are not
-    yet present in /proc/mounts, then mounts each one under /run/media/deck/.
-
-    Uses ``sudo -n mount`` directly rather than udisksctl because Decky's
-    plugin_loader runs outside the desktop session, which prevents udisks2's
-    polkit authorization from succeeding.  The ``deck`` user on SteamOS has
-    passwordless sudo.
+    Uses ``systemd-run --user --pipe udisksctl mount`` so the command runs
+    inside the deck user's systemd session, where the polkit agent is registered
+    and can authorise the filesystem-mount action without a password prompt.
 
     Returns a list of mount paths for devices that were successfully mounted.
     """
-    # Use WARNING level for mount diagnostics so they always appear in logs
-    # regardless of the user's log level setting.
     logger.warning("[mount-diag] uid=%d euid=%d user=%s",
                    os.getuid(), os.geteuid(), os.environ.get("USER", "(unset)"))
 
     mounted = _get_mounted_devices()
     discovered = _discover_usb_partitions()
     partition_paths = [p.path for p in discovered]
-    if discovered:
-        partitions = partition_paths
-    else:
-        partitions = sorted(glob.glob("/dev/sd[a-z]*[0-9]"))
+    partitions = partition_paths if discovered else sorted(glob.glob("/dev/sd[a-z]*[0-9]"))
     logger.warning("[mount-diag] partitions=%s, already mounted removable=%s",
                    partitions, [d for d in mounted if d in partitions])
 
@@ -197,25 +188,46 @@ def _mount_usb_devices() -> List[str]:
             logger.warning("[mount-diag] Skipping %s — already mounted", dev)
             continue
 
-        discovered_part = next((p for p in discovered if p.path == dev), None)
-        label = discovered_part.label if discovered_part else _get_partition_label(dev)
-        mount_point = f"/run/media/deck/{label}"
-        logger.warning("[mount-diag] Mounting %s → %s (label=%r)", dev, mount_point, label)
-
+        logger.warning("[mount-diag] Mounting %s via udisksctl", dev)
         try:
-            # Create the mount point directory
-            subprocess.run(
-                ["sudo", "-n", "mkdir", "-p", mount_point],
-                capture_output=True, text=True, timeout=5,
-            )
+            # Build a clean env from the raw process environ (/proc/self/environ)
+            # rather than os.environ, because PyInstaller clears DBUS_SESSION_BUS_ADDRESS
+            # and XDG_RUNTIME_DIR from os.environ at startup.  We also drop
+            # LD_LIBRARY_PATH so systemd-run uses system libcrypto, not the
+            # bundled one that lacks OPENSSL_3.4.0.
+            try:
+                with open("/proc/self/environ", "rb") as _ef:
+                    raw_env = dict(
+                        item.split("=", 1)
+                        for item in _ef.read().decode(errors="replace").split("\x00")
+                        if "=" in item
+                    )
+            except Exception:
+                raw_env = dict(os.environ)
+            uid = os.getuid()
+            raw_env.pop("LD_LIBRARY_PATH", None)
+            raw_env.pop("LD_PRELOAD", None)
+            raw_env.setdefault("XDG_RUNTIME_DIR", f"/run/user/{uid}")
+            raw_env.setdefault("DBUS_SESSION_BUS_ADDRESS", f"unix:path=/run/user/{uid}/bus")
             result = subprocess.run(
-                ["sudo", "-n", "mount", dev, mount_point],
+                [
+                    "systemd-run", "--user", "--pipe",
+                    "udisksctl", "mount", "--block-device", dev, "--no-user-interaction",
+                ],
                 capture_output=True, text=True, timeout=15,
+                env=raw_env,
             )
             logger.warning("[mount-diag] %s → rc=%d stdout=%r stderr=%r",
                            dev, result.returncode, result.stdout.strip(), result.stderr.strip())
             if result.returncode == 0:
-                newly_mounted.append(mount_point)
+                # stdout: "Mounted /dev/sda1 at /run/media/deck/LABEL"
+                match = re.search(r" at (/\S+)", result.stdout)
+                mount_path = match.group(1).rstrip(".") if match else None
+                if mount_path:
+                    newly_mounted.append(mount_path)
+                    logger.warning("[mount-diag] mounted %s → %s", dev, mount_path)
+                else:
+                    logger.warning("[mount-diag] could not parse mount path from: %r", result.stdout)
             else:
                 logger.warning("[mount-diag] mount failed for %s (rc=%d): %s",
                                dev, result.returncode, result.stderr.strip())

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "renpy-installer",
-  "version": "0.0.41",
+  "version": "0.0.42",
   "private": true,
   "type": "module",
   "scripts": {
@@ -23,7 +23,8 @@
   "pnpm": {
     "overrides": {
       "rollup@>=4.0.0 <4.59.0": "4.59.0",
-      "flatted@<3.4.0": "3.4.0"
+      "flatted@<3.4.2": "3.4.2",
+      "picomatch@>=4.0.0 <4.0.4": "4.0.4"
     }
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "renpy-installer",
-  "version": "0.0.42",
+  "version": "0.0.45",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "Renpy Installer",
   "author": "Morgan Blackthorne, Winds of Storm",
-  "version": "0.0.41",
+  "version": "0.0.42",
   "description": "Install Renpy games from a ZIP on USB to SD/internal storage and add them to Steam as a Non-Steam shortcut.",
   "main": "main.py",
   "api_version": 1,

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "Renpy Installer",
   "author": "Morgan Blackthorne, Winds of Storm",
-  "version": "0.0.42",
+  "version": "0.0.45",
   "description": "Install Renpy games from a ZIP on USB to SD/internal storage and add them to Steam as a Non-Steam shortcut.",
   "main": "main.py",
   "api_version": 1,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,8 @@ settings:
 
 overrides:
   rollup@>=4.0.0 <4.59.0: 4.59.0
-  flatted@<3.4.0: 3.4.0
+  flatted@<3.4.2: 3.4.2
+  picomatch@>=4.0.0 <4.0.4: 4.0.4
 
 importers:
 
@@ -341,36 +342,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
     resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
@@ -468,66 +475,79 @@ packages:
     resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.2':
     resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.2':
     resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.2':
     resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.2':
     resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.2':
     resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.2':
     resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.2':
     resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.2':
     resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.2':
     resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.2':
     resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.2':
     resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.2':
     resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.2':
     resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
@@ -828,7 +848,7 @@ packages:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      picomatch: ^3 || ^4
+      picomatch: 4.0.4
     peerDependenciesMeta:
       picomatch:
         optional: true
@@ -845,8 +865,8 @@ packages:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
 
-  flatted@3.4.0:
-    resolution: {integrity: sha512-kC6Bb+ooptOIvWj5B63EQWkF0FEnNjV2ZNkLMLZRDDduIiWeFF4iKnslwhiWxjAdbg4NzTNo6h0qLuvFrcx+Sw==}
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -958,24 +978,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -1046,10 +1070,6 @@ packages:
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
-
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
-    engines: {node: '>=12'}
 
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
@@ -1538,7 +1558,7 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
       estree-walker: 2.0.2
-      picomatch: 4.0.3
+      picomatch: 4.0.4
     optionalDependencies:
       rollup: 4.60.2
 
@@ -1941,10 +1961,6 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fdir@6.5.0(picomatch@4.0.3):
-    optionalDependencies:
-      picomatch: 4.0.3
-
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
@@ -1960,10 +1976,10 @@ snapshots:
 
   flat-cache@4.0.1:
     dependencies:
-      flatted: 3.4.0
+      flatted: 3.4.2
       keyv: 4.5.4
 
-  flatted@3.4.0: {}
+  flatted@3.4.2: {}
 
   fsevents@2.3.3:
     optional: true
@@ -2123,8 +2139,6 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  picomatch@4.0.3: {}
-
   picomatch@4.0.4: {}
 
   postcss@8.5.10:
@@ -2254,8 +2268,8 @@ snapshots:
 
   tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tinyglobby@0.2.16:
     dependencies:
@@ -2322,7 +2336,7 @@ snapshots:
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       std-env: 4.1.0
       tinybench: 2.9.0
       tinyexec: 1.1.1


### PR DESCRIPTION
## Summary
- Updated `pnpm.overrides` to force `flatted` ≥ 3.4.2 and `picomatch` ≥ 4.0.4, resolving 2 high + 1 moderate audit vulnerabilities
- Fixed USB mount refresh: replaced `sudo -n mount/mkdir` with `systemd-run --user udisksctl mount`, which works without any sudoers entries
- Reads subprocess env from `/proc/self/environ` (PyInstaller clears `DBUS_SESSION_BUS_ADDRESS` / `XDG_RUNTIME_DIR` from `os.environ`); strips `LD_LIBRARY_PATH` so system `libcrypto` is used instead of the bundled one missing `OPENSSL_3.4.0`

## Vulnerabilities fixed
| Severity | Package | Advisory |
|---|---|---|
| High | `flatted` | GHSA-rf6f-7fwh-wjgh — Prototype Pollution |
| High | `picomatch` | GHSA-c2c7-rcm5-vvqj — ReDoS |
| Moderate | `picomatch` | GHSA-3v7f-55p6-f55p — Method Injection |

## Test plan
- [x] `pnpm audit` clean
- [x] `pnpm run lint` passes
- [x] `pnpm run build` produces `dist/index.js`
- [x] USB mount refresh on Deck: `/dev/sda1` mounted at `/run/media/deck/AA9C-5ECD`, 7 ZIPs found

🤖 Generated with [Claude Code](https://claude.com/claude-code)