### PR TITLE
chore: add reviewer to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,37 +1,41 @@
 version: 2
 updates:
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-    groups:
-      frontend-dependencies:
-        patterns:
-          - "*"
-
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-    groups:
-      python-test-dependencies:
-        patterns:
-          - "*"
-
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-    groups:
-      github-actions:
-        patterns:
-          - "*"
+- package-ecosystem: npm
+  directory: /
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 5
+  labels:
+  - dependencies
+  groups:
+    frontend-dependencies:
+      patterns:
+      - '*'
+  reviewers:
+  - jasmeralia
+- package-ecosystem: pip
+  directory: /
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 5
+  labels:
+  - dependencies
+  groups:
+    python-test-dependencies:
+      patterns:
+      - '*'
+  reviewers:
+  - jasmeralia
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 5
+  labels:
+  - dependencies
+  groups:
+    github-actions:
+      patterns:
+      - '*'
+  reviewers:
+  - jasmeralia


### PR DESCRIPTION
Adds `jasmeralia` as a reviewer to every dependabot update block so that dependabot PRs appear under https://github.com/pulls/reviews.

Note: CODEOWNERS alone does not trigger review requests for dependabot PRs; the `reviewers` field in dependabot.yml is required.