### PR TITLE
chore: ignore typescript major version bumps in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,10 @@ updates:
     frontend-dependencies:
       patterns:
       - '*'
+  ignore:
+  - dependency-name: typescript
+    update-types:
+    - version-update:semver-major
   reviewers:
   - jasmeralia
 - package-ecosystem: pip


### PR DESCRIPTION
## Summary
- Adds a semver-major ignore rule for `typescript` in dependabot.yml
- `typescript-eslint@8.x` declares `typescript: ">=4.8.4 <6.1.0"` as a peer dep and crashes on TypeScript 7 (`Cannot read properties of undefined (reading 'Cjs')`)
- Closes #26; dependabot will resume minor/patch bumps within the 6.x range

## Test plan
- [ ] CI passes (no code changes, just config)
- [ ] Confirm dependabot stops re-raising the TS 6→7 bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EVaFRaXvFHtZnAhDRAp6uM