### PR TITLE
Fix dependabot reviewer auto-assignment via CODEOWNERS

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,8 +15,6 @@ updates:
   - dependency-name: typescript
     update-types:
     - version-update:semver-major
-  reviewers:
-  - jasmeralia
 - package-ecosystem: pip
   directory: /
   schedule:
@@ -28,8 +26,6 @@ updates:
     python-test-dependencies:
       patterns:
       - '*'
-  reviewers:
-  - jasmeralia
 - package-ecosystem: github-actions
   directory: /
   schedule:
@@ -41,5 +37,3 @@ updates:
     github-actions:
       patterns:
       - '*'
-  reviewers:
-  - jasmeralia


### PR DESCRIPTION
## Summary
- GitHub deprecated and removed the `reviewers` key from `dependabot.yml` in 2025, replacing it with CODEOWNERS-based review assignment. The key had become a silent no-op, which is why dependabot PRs stopped requesting jasmeralia as a reviewer.
- Removes the dead `reviewers` key from `dependabot.yml`.
- Adds/confirms a `CODEOWNERS` file (`* @jasmeralia`) so dependabot PRs get a review request again.

## Test plan
- [x] Confirmed via GitHub API that repos with a working CODEOWNERS file show `review_requested` events on recent dependabot PRs
- [x] Confirmed removed key was an exact, isolated match (no other config touched)
