### PR TITLE
Add CODEOWNERS in both root and .github locations

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @jasmeralia


### PR DESCRIPTION
## Summary
- Adds a CODEOWNERS file in both the repo root and `.github/` so the review-request mechanism works regardless of which location a tool checks first.
- On private repos that previously had no CODEOWNERS at all (steam-typhoon, mfc-chat-overlay), this also adds the file for the first time, along with removing the dead `reviewers` key from dependabot.yml (private repos on this account currently don't get CODEOWNERS-based auto-review-request without GitHub Pro, but this is harmless to add now and will start working automatically if that changes).

## Test plan
- [x] Verified both CODEOWNERS files contain identical content (`* @jasmeralia`)
- [x] Verified dependabot.yml has no remaining `reviewers` key
