### PR TITLE
chore: add reviewers to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,8 @@ updates:
   - dependency-name: typescript
     update-types:
     - version-update:semver-major
+  reviewers:
+  - jasmeralia
 - package-ecosystem: pip
   directory: /
   schedule:
@@ -26,6 +28,8 @@ updates:
     python-test-dependencies:
       patterns:
       - '*'
+  reviewers:
+  - jasmeralia
 - package-ecosystem: github-actions
   directory: /
   schedule:
@@ -37,3 +41,5 @@ updates:
     github-actions:
       patterns:
       - '*'
+  reviewers:
+  - jasmeralia


### PR DESCRIPTION
## Summary
- Adds `jasmeralia` as reviewer to all dependabot update blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9YkRz1NALGotAburq1g4S