### PR TITLE
chore: bump version to 0.0.49

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "renpy-installer",
-  "version": "0.0.48",
+  "version": "0.0.49",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "Renpy Installer",
   "author": "Morgan Blackthorne, Winds of Storm",
-  "version": "0.0.48",
+  "version": "0.0.49",
   "description": "Install Renpy games from a ZIP on USB to SD/internal storage and add them to Steam as a Non-Steam shortcut.",
   "main": "main.py",
   "api_version": 1,


### PR DESCRIPTION
## Summary
- Bumps version to 0.0.49 in `package.json` and `plugin.json`

## Test plan
- [ ] CI passes
- [ ] Merge and tag `v0.0.49` to trigger release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EVaFRaXvFHtZnAhDRAp6uM