### PR TITLE
fix: bump pnpm to 11, Node to 22 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,11 +22,11 @@ jobs:
 
       - uses: pnpm/action-setup@v6
         with:
-          version: 9
+          version: 11
 
       - uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'pnpm'
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- Matches `release.yml` pnpm/Node versions to `ci.yml` (pnpm 11, Node 22)
- pnpm 9 hits the retired npm audit endpoints; pnpm 11 requires Node >=22

## Test plan
- [ ] CI passes
- [ ] Merge, delete the failed v0.0.49 tag, re-tag to trigger a clean release build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EVaFRaXvFHtZnAhDRAp6uM